### PR TITLE
Add official "class*" nickname.

### DIFF
--- a/source/package.lisp
+++ b/source/package.lisp
@@ -7,6 +7,7 @@
 (in-package :common-lisp-user)
 
 (defpackage :hu.dwim.defclass-star
+  (:nicknames :class*)
   (:use :common-lisp)
   (:export #:defclass*
            #:defcondition*


### PR DESCRIPTION
"hu.dwim.defclass-star" is rather long, "class*" is much more convenient as a
package nickname.