### PR TITLE
Fix export to only export symbols of current package.

### DIFF
--- a/source/defclass-star.lisp
+++ b/source/defclass-star.lisp
@@ -256,9 +256,14 @@
               `(progn
                  ,result
                  (eval-when (:compile-toplevel :load-toplevel :execute)
-                   (export '(,@(append (when *export-class-name-p*
-                                         (list name))
-                                       *symbols-to-export*))
+                   ;; Don't try to export symbols that don't belong to *package*.
+                   ;; This can happen when inheriting from a class and
+                   ;; overriding some slot.
+                   (export '(,@(remove-if (lambda (sym)
+                                            (not (eq (symbol-package sym) *package*)))
+                                (append (when *export-class-name-p*
+                                          (list name))
+                                 *symbols-to-export*)))
                            ,(package-name *package*)))
                  (find-class ',name nil))
               result))))))


### PR DESCRIPTION
Previously, defclass-star* would fail when overriding a slot of a superclass.
Example recipe:

```lisp
    (setf hu.dwim.defclass-star::*export-slot-names-p* t)
    (hu.dwim.defclass-star:defclass* foo ()
        ((foo-name :initform "foo name")))

    (defpackage foo-package
      (:use :cl))
    (in-package foo-package)

    (hu.dwim.defclass-star:defclass* bar (cl-user:foo)
        ((cl-user:foo-name :initform "bar name")))
```